### PR TITLE
v0.4.0

### DIFF
--- a/.docs/Makefile
+++ b/.docs/Makefile
@@ -1,3 +1,5 @@
+.PHONY: help docs Makefile
+
 SPHINXOPTS  ?= -c .
 SPHINXBUILD ?= sphinx-build
 SOURCEDIR    = source
@@ -5,24 +7,16 @@ BUILDDIR     = build
 REFERENCEDIR = $(SOURCEDIR)/refs
 DOCSDIR      = ../docs
 
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-.PHONY: clear-refs docs pages help Makefile
-
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-clear:
-	rm -rf build
-
-clear-refs:
-	find $(REFERENCEDIR) -type f -name *.rst ! -name index.rst -exec rm -f {} \;
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 docs:
-	make clear
+	rm -rf build
 	make html
-	make clear-refs
+	find $(REFERENCEDIR) -type f -name *.rst ! -name index.rst -exec rm -f {} \;
 	mkdir -p $(DOCSDIR) && rm -rf $(DOCSDIR)/*
 	cp -r build/html/{_static,refs,*.html} $(DOCSDIR)
 

--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -2,7 +2,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("../pure_utils/"))
+sys.path.insert(0, os.path.abspath("../pure_utils"))
+
+autodoc_mock_imports = ["pure_utils"]
 
 DOCS_ROOT_DIR = Path(__file__).resolve(strict=True).parent
 

--- a/.docs/source/changelog.rst
+++ b/.docs/source/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.4.0 - [2024-02-00]
+---------------------
+* ...
+
 v0.3.0 - [2024-02-04]
 ---------------------
 * Add new module - `dt` (utilities for working with datetime objects).

--- a/.docs/source/changelog.rst
+++ b/.docs/source/changelog.rst
@@ -1,11 +1,13 @@
 Changelog
 =========
 
-v0.4.0 - [2024-02-00]
+v0.4.0 - [2024-02-19]
 ---------------------
-* Add support Python3.12 into ci scenario.
 * Add several tests (for `dt` module) for python3.10 only.
-* Add new module - `debug` (utilities for debugging and development.).
+* Add new module - `debug` (utilities for debugging and development).
+* Add new module - `profiler` (helper classes for working with the cProfile).
+* Refactor .docs/Makefile
+* Add support Python3.12 into ci scenario.
 * Use flake8 explicitly into Makefile and ci scenario.
 * Remove `pyproject-flake8` optional dependencies, because it's orphaned on github.
 

--- a/.docs/source/changelog.rst
+++ b/.docs/source/changelog.rst
@@ -3,10 +3,11 @@ Changelog
 
 v0.4.0 - [2024-02-00]
 ---------------------
-* Add new module - `debug` (utilities for debugging and development.).
-* Remove `pyproject-flake8` optional dependencies, because it's orphaned on github.
-* Use flake8 explicitly into Makefile and ci scenario.
 * Add support Python3.12 into ci scenario.
+* Add several tests (for `dt` module) for python3.10 only.
+* Add new module - `debug` (utilities for debugging and development.).
+* Use flake8 explicitly into Makefile and ci scenario.
+* Remove `pyproject-flake8` optional dependencies, because it's orphaned on github.
 
 v0.3.0 - [2024-02-04]
 ---------------------

--- a/.docs/source/changelog.rst
+++ b/.docs/source/changelog.rst
@@ -3,7 +3,10 @@ Changelog
 
 v0.4.0 - [2024-02-00]
 ---------------------
-* ...
+* Add new module - `debug` (utilities for debugging and development.).
+* Remove `pyproject-flake8` optional dependencies, because it's orphaned on github.
+* Use flake8 explicitly into Makefile and ci scenario.
+* Add support Python3.12 into ci scenario.
 
 v0.3.0 - [2024-02-04]
 ---------------------

--- a/.docs/source/commands.rst
+++ b/.docs/source/commands.rst
@@ -19,7 +19,7 @@ Distributing
 
 Development
 -----------
-- ``make clean`` - Clean temporary files and caches.
+- ``make cleanup`` - Clean up python temporary files and caches.
 - ``make format`` - Fromat the code (by black and isort).
 - ``make lint`` - Check code style and types (by flake8, pydocstyle and mypy).
 - ``make tests`` - Run tests with coverage measure (output to terminal).

--- a/.docs/source/refs/index.rst
+++ b/.docs/source/refs/index.rst
@@ -3,5 +3,6 @@
    :recursive:
 
       common
-      strings
+      debug
       dt
+      strings

--- a/.docs/source/refs/index.rst
+++ b/.docs/source/refs/index.rst
@@ -5,4 +5,5 @@
       common
       debug
       dt
+      profiler
       strings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.10", "3.11"]
+                python-version: ["3.10", "3.11", "3.12"]
         env:
             USING_COVERAGE: "3.10"
         steps:
@@ -24,8 +24,8 @@ jobs:
               run: make deps
             - name: Check pep8
               run: |
-                  python3 -m pflake8 pure_utils/
-                  python3 -m pflake8 --ignore=F401 tests/
+                  python -m flake8 --max-complexity 10 --max-line-length 100 --ignore D --extend-ignore E203,W503 pure_utils
+                  python -m flake8 --max-complexity 10 --max-line-length 100 --ignore D --extend-ignore E203,W503,F401 tests
             - name: Check code style
               run: |
                   python3 -m black --line-length 100 --check pure_utils/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
             matrix:
                 python-version: ["3.10", "3.11", "3.12"]
         env:
-            USING_COVERAGE: "3.10"
+            USING_COVERAGE: "3.12"
         steps:
             - name: Checkout sources
               uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ MYPY  = python -m mypy
 BUILD = python -m build
 ISORT = python -m isort
 BLACK = python -m black
-FLAKE = python -m pflake8
 PYDOC = python -m pydocstyle
+FLAKE = python -m flake8 --max-complexity 10 --max-line-length 100 --ignore D
 
 deps-dev:
 	$(PIP) install '.[dev]' --upgrade
@@ -40,8 +40,10 @@ format:
 	$(ISORT) tests/
 
 lint:
-	printf "[flake8]: checking ... "
-	$(FLAKE) pure_utils/ && printf "OK\n"
+	printf "[flake8]: pure_utils/ checking ... "
+	$(FLAKE) --extend-ignore E203,W503 pure_utils && printf "OK\n"
+	printf "[flake8]: tests/ checking ... "
+	$(FLAKE) --extend-ignore E203,W503,F401 tests && printf "OK\n"
 	printf "[mypy]: checking ... "
 	$(MYPY) --install-types --non-interactive pure_utils/ && printf "OK\n"
 	printf "[pydocstyle]: checking ... "

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: deps-dev deps-docs deps-build deps build-sdist build-wheel build upload format lint tests clean help
+.PHONY: deps-dev deps-docs deps-build deps build-sdist build-wheel build upload format lint tests cleanup help
 MAKEFLAGS += --silent
 
 # Aliases
@@ -58,7 +58,7 @@ tests-cov-html:
 tests-cov-json:
 	python -m pytest --cov pure_utils --cov-report json
 
-clean:
+cleanup:
 	rm -rf .pytest_cache/ .mypy_cache/ junit/ build/ dist/ coverage_report/
 	find . -not -path './.venv*' -path '*/__pycache__*' -delete
 	find . -not -path './.venv*' -path '*/*.egg-info*' -delete
@@ -83,7 +83,7 @@ help:
 	echo "tests-cov-json\tRun tests with coverage measure (output to json [coverage.json])."
 	echo "tests-cov-html\tRun tests with coverage measure (output to html [coverage_report/])."
 	echo
-	echo "clean\t\tClean temporary files and caches."
+	echo "cleanup\t\tClean up python temporary files and caches."
 	echo "format\t\tFromat the code (by black and isort)."
 	echo "lint\t\tCheck code style and types (by flake8, pydocstyle and mypy)."
 	echo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pure-utils
 
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pure-utils)
 ![Build Status](https://github.com/p3t3rbr0/py3-pure-utils/actions/workflows/ci.yaml/badge.svg?branch=master)
 ![PyPI Version](https://img.shields.io/pypi/v/pure-utils)
 [![Code Coverage](https://codecov.io/gh/p3t3rbr0/py3-pure-utils/graph/badge.svg?token=283H0MAGUP)](https://codecov.io/gh/p3t3rbr0/py3-pure-utils)

--- a/README.md
+++ b/README.md
@@ -21,16 +21,21 @@ Main principles:
 
 * [common](https://p3t3rbr0.github.io/py3-pure-utils/refs/common.html) - The common purpose utilities.
   * [Singleton](https://p3t3rbr0.github.io/py3-pure-utils/refs/common.html#common.Singleton) - A metaclass that implements the singleton pattern for inheritors.
-* [strings](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html) - Utilities for working with strings.
-  * [genstr](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.genstr) - Generate ASCII-string with random letters.
-  * [gzip](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.gzip) - Compress string (or bytes string) with gzip compression level.
-  * [gunzip](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.gunzip) - Decompress bytes (earlier compressed with gzip) to string.
+* [debug](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html) - Utilities for debugging and development.
+  * [around](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.around) - ...
+  * [caller](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.caller) - ...
+  * [deltatime](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.deltatime) - ...
+  * [profileit](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.profileit) - ...
 * [dt](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html) - Utilities for working with datetime objects.
   * [apply_tz](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.apply_tz) - Apply timezone context to datetime object.
   * [iso2format](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.iso2format) - Convert ISO-8601 datetime string into a string of specified format.
   * [iso2dmy](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.iso2dmy) - Convert ISO-8601 datetime string into a string of DMY (DD.MM.YYYY) format.
   * [iso2ymd](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.iso2ymd) - Convert ISO-8601 datetime string into a string of YMD (YYYY-MM-DD) format.
   * [round_by](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.round_by) - Round datetime, discarding excessive precision.
+* [strings](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html) - Utilities for working with strings.
+  * [genstr](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.genstr) - Generate ASCII-string with random letters.
+  * [gzip](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.gzip) - Compress string (or bytes string) with gzip compression level.
+  * [gunzip](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.gunzip) - Decompress bytes (earlier compressed with gzip) to string.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,18 @@ Main principles:
 * [common](https://p3t3rbr0.github.io/py3-pure-utils/refs/common.html) - The common purpose utilities.
   * [Singleton](https://p3t3rbr0.github.io/py3-pure-utils/refs/common.html#common.Singleton) - A metaclass that implements the singleton pattern for inheritors.
 * [debug](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html) - Utilities for debugging and development.
-  * [around](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.around) - ...
-  * [caller](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.caller) - ...
-  * [deltatime](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.deltatime) - ...
-  * [profileit](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.profileit) - ...
+  * [around](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.around) - Add additional behavior before and after execution of decorated function.
+  * [caller](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.caller) - Get the name of calling function/method (from current function/method context).
+  * [deltatime](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.deltatime) - Measure execution time of decorated function and print it to log.
+  * [profileit](https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.profileit) - Profile decorated function being with 'cProfile'.
 * [dt](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html) - Utilities for working with datetime objects.
   * [apply_tz](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.apply_tz) - Apply timezone context to datetime object.
   * [iso2format](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.iso2format) - Convert ISO-8601 datetime string into a string of specified format.
   * [iso2dmy](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.iso2dmy) - Convert ISO-8601 datetime string into a string of DMY (DD.MM.YYYY) format.
   * [iso2ymd](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.iso2ymd) - Convert ISO-8601 datetime string into a string of YMD (YYYY-MM-DD) format.
   * [round_by](https://p3t3rbr0.github.io/py3-pure-utils/refs/dt.html#dt.round_by) - Round datetime, discarding excessive precision.
+* [profiler](https://p3t3rbr0.github.io/py3-pure-utils/refs/profiler.html) - Helper classes for working with the cProfile.
+  * [Profiler](https://p3t3rbr0.github.io/py3-pure-utils/refs/profiler.html#profiler.Profiler) - ....
 * [strings](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html) - Utilities for working with strings.
   * [genstr](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.genstr) - Generate ASCII-string with random letters.
   * [gzip](https://p3t3rbr0.github.io/py3-pure-utils/refs/strings.html#strings.gzip) - Compress string (or bytes string) with gzip compression level.

--- a/pure_utils/__init__.py
+++ b/pure_utils/__init__.py
@@ -1,6 +1,6 @@
 """Utilities imports."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from .common import *  # noqa: F401, F403
 from .dt import *  # noqa: F401, F403

--- a/pure_utils/__init__.py
+++ b/pure_utils/__init__.py
@@ -5,4 +5,5 @@ __version__ = "0.4.0"
 from .common import *  # noqa: F401, F403
 from .debug import *  # noqa: F401, F403
 from .dt import *  # noqa: F401, F403
+from .profiler import *  # noqa: F401, F403
 from .strings import *  # noqa: F401, F403

--- a/pure_utils/__init__.py
+++ b/pure_utils/__init__.py
@@ -3,5 +3,6 @@
 __version__ = "0.4.0"
 
 from .common import *  # noqa: F401, F403
+from .debug import *  # noqa: F401, F403
 from .dt import *  # noqa: F401, F403
 from .strings import *  # noqa: F401, F403

--- a/pure_utils/_pstats.py
+++ b/pure_utils/_pstats.py
@@ -1,0 +1,189 @@
+"""Private module for encapsulating low-level work with profiler stats."""
+
+from pstats import Stats
+from typing import Iterable, Mapping, Sequence, TypeAlias
+
+SerializedPStatsT: TypeAlias = str | bytes | Mapping
+
+
+class PStats(Stats):
+    """A dummy override to explicitly describe class attributes.
+
+    In the standard library, attributes are not defined in the constructor,
+    which breaks the type analyzer.
+    """
+
+    def __init__(self, *args, stream=None) -> None:
+        """Initialize profile stats object."""
+        self.all_callees = None
+        self.files: Sequence = []
+        self.fcn_list = None
+        self.total_tt = 0
+        self.total_calls = 0
+        self.prim_calls = 0
+        self.max_name_len = 0
+        self.top_level: Iterable = set()
+        self.stats: Mapping = {}
+        self.sort_arg_dict: Mapping = {}
+
+        super().__init__(*args, stream)
+
+
+class PStatsSerializer:
+    """Base class for serializer of profiling results."""
+
+    def __init__(self, pstats: PStats, amount: int) -> None:
+        """Initialize base stats serializer object."""
+        self.pstats = pstats
+        self.amount = amount
+
+    def serialize(self) -> SerializedPStatsT:
+        """Interface for serialization method of profiling results.
+
+        Must be implemented in child classes.
+
+        Raises:
+            NotImplementedError: If called directly.
+        """
+        raise NotImplementedError
+
+
+class StringPStatsSerializer(PStatsSerializer):
+    """..."""
+
+    @property
+    def indent(self) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        return " " * 8
+
+    @property
+    def title(self) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        return "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)"
+
+    def f8(self, x: float) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        return f"{x:8.3f}"
+
+    def func_std_string(self, func_name) -> str:
+        """...
+
+        Args:
+            func_name: ...
+
+        Returns:
+            ...
+        """
+        if func_name[:2] == ("~", 0):
+            # special case for built-in functions
+            name = func_name[2]
+            if name.startswith("<") and name.endswith(">"):
+                return "{%s}" % name[1:-1]
+            else:
+                return name
+        else:
+            return "%s:%d(%s)" % func_name
+
+    def print_line(self, func) -> str:
+        """...
+
+        Args:
+            func: ...
+
+        Returns:
+            ...
+        """
+        lines = []
+        cc, nc, tt, ct, callers = self.pstats.stats[func]
+        c = str(nc)
+
+        if nc != cc:
+            c = c + "/" + str(cc)
+
+        lines.append(f"{c.rjust(9)} ")
+        lines.append(f"{self.f8(tt)} ")
+
+        if nc == 0:
+            lines.append(f"{self.indent} ")
+        else:
+            lines.append(f"{self.f8(tt / nc)} ")
+
+        lines.append(f"{self.f8(ct)} ")
+
+        if cc == 0:
+            lines.append(f"{self.indent} ")
+        else:
+            lines.append(f"{self.f8(ct / cc)} ")
+
+        lines.append(self.func_std_string(func))
+
+        return "".join(lines)
+
+    def get_func_list(self) -> tuple[int, Sequence]:
+        """...
+
+        Returns:
+            ...
+        """
+        width = self.pstats.max_name_len
+
+        if self.pstats.fcn_list:
+            func_list = self.pstats.fcn_list[:]
+        else:
+            func_list = list(self.pstats.stats.keys())
+
+        count = len(func_list)
+
+        if not func_list:
+            return 0, func_list
+
+        if count < len(self.pstats.stats):
+            width = 0
+            for func in func_list:
+                if len(self.func_std_string(func)) > width:
+                    width = len(self.func_std_string(func))
+
+        return width + 2, func_list
+
+    def serialize(self) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        lines = []
+
+        for filename in self.pstats.files:
+            lines.append(filename)
+
+        for func in self.pstats.top_level:
+            lines.append(f"{self.indent}{func[2]}")
+
+        lines.append(f"{self.pstats.total_calls} function calls ")
+
+        if self.pstats.total_calls != self.pstats.prim_calls:
+            lines.append(f"({self.pstats.prim_calls!r} primitive calls) ")
+
+        lines.append(f"in {self.pstats.total_tt:.3f} seconds\n\n")
+
+        _, func_list = self.get_func_list()
+
+        if func_list:
+            lines.append("Ordered by: cumulative time, function name\n\n")
+            lines.append(f"{self.title}\n")
+            for func in func_list:
+                lines.append(f"{self.print_line(func)}\n")
+
+        return "".join(lines)

--- a/pure_utils/common.py
+++ b/pure_utils/common.py
@@ -11,9 +11,7 @@ T = TypeVar("T", bound="Singleton")
 class Singleton(type):
     """A metaclass that implements the singleton pattern for inheritors.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import Singleton
 

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from functools import wraps
 from inspect import stack
 from logging import Logger
-from pstats import Stats
 from time import time
 from typing import Any, Callable, Optional, TypeAlias
 
@@ -221,7 +220,7 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
 
     def decorate(func) -> CallableAnyT:
         @wraps(func)
-        def wrapper(*args, **kwargs) -> tuple[Any, Stats]:
+        def wrapper(*args, **kwargs) -> tuple[Any, str]:
             retval = None
             profiler = Profiler()
 
@@ -233,7 +232,7 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
                 )
 
             if logger:
-                logger.log(msg=f"[PROFILEIT]: {profiler_stats}", level=logger.level)
+                logger.log(msg=f"[PROFILEIT]: {profiler_stats!r}", level=logger.level)
 
             return retval, profiler_stats
 

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -1,0 +1,154 @@
+"""Utilities for debugging and development."""
+
+from copy import deepcopy
+from cProfile import Profile
+from functools import wraps
+from inspect import stack
+from logging import Logger
+from pstats import Stats
+from time import time
+from typing import Any, Callable, Optional, TypeAlias
+
+CallableAnyT: TypeAlias = Callable[[Any], Any]
+
+DEFAULT_STACK_SIZE: int = 10
+DEFAULT_STACK_FRAME: int = 2
+
+
+def deltatime(logger: Optional[Logger] = None) -> Callable:
+    """Measure execution time of decorated function and print it to log.
+
+    Args:
+        logger: Optional logger object for printing execution time to file.
+    """
+
+    def decorate(func) -> CallableAnyT:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            t0 = time()
+            retval = func(*args, **kwargs)
+            delta = float(f"{time()-t0:.3f}")
+            if logger:
+                logger.debug(f"[DELTATIME]: '{func.__name__}' ({delta} sec.)")
+            return retval, delta
+
+        return wrapper
+
+    return decorate
+
+
+def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_SIZE) -> Callable:
+    """Profile decorated function being with 'cProfile'.
+
+    Args:
+        logger: Optional logger object for printing execution time to file.
+        stack_size: Stack size limit for profiler results.
+    """
+    profiler = Profile()
+
+    def decorate(func) -> CallableAnyT:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = None
+            try:
+                result = profiler.runcall(func, *args, **kwargs)
+            finally:
+                stack_info = (
+                    Stats(profiler)
+                    .strip_dirs()
+                    .sort_stats("cumulative", "name")
+                    .print_stats(stack_size)
+                )
+                if logger:
+                    logger.debug(f"[PROFILEIT]: {stack_info}")
+            return result, stack_info
+
+        return wrapper
+
+    return decorate
+
+
+def caller(at_frame: int = DEFAULT_STACK_FRAME) -> str:
+    """Get the name of calling function/method (from current function/method context).
+
+    Args:
+        at_frame: The frame index number on the call stack (default 2).
+                  Need increased with each wrap to decorator.
+
+    Returns:
+        The name of calling function/method.
+
+    Usage:
+
+    .. code-block:: python
+
+        from pure_utils import caller
+
+        def func1(*args, **kwargs):
+            print(f"I'am 'func1'. '{caller()}' called me.")
+
+        def func2(*args, **kwargs):
+            return func1()
+
+        func2()  # I'am 'func1'. 'func2' called me.
+    """
+    return str(stack()[at_frame].function)
+
+
+def around(before: Optional[Callable] = None, after: Optional[Callable] = None) -> Callable:
+    """Add additional behavior before and after execution of decorated function.
+
+    Args:
+        before: A reference to afunction/method that must be executed
+                BEFORE calling the decorated function.
+        after: A reference to afunction/method that must be executed
+               AFTER calling the decorated function.
+
+    The decorator highlights additional memory for data exchange
+    capabilities between before and after handlers.
+
+    This memory is transferred in the form of additional parameter ("_pipe")
+    in the kwargs named argument dictionary.
+
+    Usage:
+
+    .. code-block:: python
+
+        from pure_utils import around
+
+        def before_handler(*args, **kwargs):
+            kwargs["_pipe"]["key"] = "some data (from before to after handlers)"
+            print("before!")
+
+        def after_handler(*args, **kwargs):
+            print(f"after: {kwargs['_pipe']['key']} !")
+
+        @around(before=before_handler, after=after_handler)
+        def func():
+            print("in da func")
+
+        func()
+        # before!
+        # in da func
+        # after: some data (from before to after handlers) !
+    """
+
+    def decorate(func) -> CallableAnyT:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            _buffer = {}
+            _args, _kwargs = (deepcopy(args), kwargs.copy())
+
+            if before:
+                before(*_args, _pipe=_buffer, **_kwargs)
+
+            result = func(*args, **kwargs)
+
+            if after:
+                after(*_args, _pipe=_buffer, **_kwargs)
+
+            return result
+
+        return wrapper
+
+    return decorate

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -7,7 +7,8 @@ from logging import Logger
 from time import time
 from typing import Any, Callable, Optional, TypeAlias
 
-from .profiler import Profiler, StringProfileStatsSerializer
+from ._pstats import SerializedPStatsT, StringPStatsSerializer
+from .profiler import Profiler
 
 __all__ = ["around", "caller", "deltatime", "profileit"]
 
@@ -220,7 +221,7 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
 
     def decorate(func) -> CallableAnyT:
         @wraps(func)
-        def wrapper(*args, **kwargs) -> tuple[Any, str]:
+        def wrapper(*args, **kwargs) -> tuple[Any, SerializedPStatsT]:
             retval = None
             profiler = Profiler()
 
@@ -228,7 +229,7 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
                 retval = profiler.profile(func, *args, **kwargs)
             finally:
                 profiler_stats = profiler.serialize_stats(
-                    serializer=StringProfileStatsSerializer, stack_size=stack_size
+                    serializer=StringPStatsSerializer, stack_size=stack_size
                 )
 
             if logger:

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -7,12 +7,12 @@ from logging import Logger
 from time import time
 from typing import Any, Callable, Optional, TypeAlias
 
-from pure_utils._pstats import SerializedPStatsT, StringPStatsSerializer
+from pure_utils._pstats import ProfilerStatsT, StringPStatsSerializer
 from pure_utils.profiler import Profiler
 
 __all__ = ["around", "caller", "deltatime", "profileit"]
 
-CallableAnyT: TypeAlias = Callable[[Any], Any]
+AnyCallableT: TypeAlias = Callable[[Any], Any]
 
 DEFAULT_STACK_SIZE: int = 20
 DEFAULT_STACK_FRAME: int = 2
@@ -71,7 +71,7 @@ def around(before: Optional[Callable] = None, after: Optional[Callable] = None) 
         # in da func3
     """
 
-    def decorate(func) -> CallableAnyT:
+    def decorate(func) -> AnyCallableT:
         @wraps(func)
         def wrapper(*args, **kwargs):
             if not before and not after:
@@ -156,7 +156,7 @@ def deltatime(logger: Optional[Logger] = None) -> Callable:
         # DEBUG:root:[DELTATIME]: 'aim_func2' (0.025 sec.)
     """
 
-    def decorate(func) -> CallableAnyT:
+    def decorate(func) -> AnyCallableT:
         @wraps(func)
         def wrapper(*args, **kwargs) -> tuple[Any, float]:
             t0 = time()
@@ -219,16 +219,16 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
     func4()
     """
 
-    def decorate(func) -> CallableAnyT:
+    def decorate(func) -> AnyCallableT:
         @wraps(func)
-        def wrapper(*args, **kwargs) -> tuple[Any, SerializedPStatsT]:
+        def wrapper(*args, **kwargs) -> tuple[Any, ProfilerStatsT]:
             retval = None
             profiler = Profiler()
 
             try:
                 retval = profiler.profile(func, *args, **kwargs)
             finally:
-                profiler_stats = profiler.serialize_stats(
+                profiler_stats = profiler.serialize_result(
                     serializer=StringPStatsSerializer, stack_size=stack_size
                 )
 

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -27,7 +27,7 @@ def deltatime(logger: Optional[Logger] = None) -> Callable:
         def wrapper(*args, **kwargs):
             t0 = time()
             retval = func(*args, **kwargs)
-            delta = float(f"{time()-t0:.3f}")
+            delta = float(f"{time() - t0:.3f}")
             if logger:
                 logger.debug(f"[DELTATIME]: '{func.__name__}' ({delta} sec.)")
             return retval, delta

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -180,43 +180,44 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
 
     Example::
 
-    from pure_utils import profileit
+        from pure_utils import profileit
 
-    def func1():
-        ...
+        def func1():
+            ...
 
-    def func2():
-        func1()
+        def func2():
+            func1()
 
-    def func3():
-        func2()
+        def func3():
+            func2()
 
-    @profileit()
-    def func4():
-        func3()
+        @profileit()
+        def func4():
+            func3()
 
-    _, profile_info = func4()
-    print(profile_info)
-    # 5 function calls in 0.000 seconds
-    #    Ordered by: cumulative time, function name
-    #    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-    #         1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
-    #         1    0.000    0.000    0.000    0.000 scriptname.py:13(func4)
-    #         1    0.000    0.000    0.000    0.000 scriptname.py:10(func3)
-    #         1    0.000    0.000    0.000    0.000 scriptname.py:7(func2)
-    #         1    0.000    0.000    0.000    0.000 scriptname.py:4(func1)
-    # <pstats.Stats object at 0x10cf1a390>
+        _, profile_info = func4()
+        print(profile_info)
 
-    # !!! Or use decorator with logger (side effect) !!!
+        5 function calls in 0.000 seconds
+           Ordered by: cumulative time, function name
+           ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+              1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+              1    0.000    0.000    0.000    0.000 scriptname.py:13(func4)
+              1    0.000    0.000    0.000    0.000 scriptname.py:10(func3)
+              1    0.000    0.000    0.000    0.000 scriptname.py:7(func2)
+              1    0.000    0.000    0.000    0.000 scriptname.py:4(func1)
+        <pstats.Stats object at 0x10cf1a390>
 
-    from logging import getLogger, DEBUG, basicConfig
-    basicConfig(level=DEBUG)
+        # !!! Or use decorator with logger (side effect) !!!
 
-    @profileit(logger=getLogger())
-    def func4():
-        func3()
+        from logging import getLogger, DEBUG, basicConfig
+        basicConfig(level=DEBUG)
 
-    func4()
+        @profileit(logger=getLogger())
+        def func4():
+            func3()
+
+        func4()
     """
 
     def decorate(func) -> AnyCallableT:

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -7,8 +7,8 @@ from logging import Logger
 from time import time
 from typing import Any, Callable, Optional, TypeAlias
 
-from ._pstats import SerializedPStatsT, StringPStatsSerializer
-from .profiler import Profiler
+from pure_utils._pstats import SerializedPStatsT, StringPStatsSerializer
+from pure_utils.profiler import Profiler
 
 __all__ = ["around", "caller", "deltatime", "profileit"]
 
@@ -233,7 +233,7 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
                 )
 
             if logger:
-                logger.log(msg=f"[PROFILEIT]: {profiler_stats!r}", level=logger.level)
+                logger.log(msg=f"[PROFILEIT]: {str(profiler_stats)}", level=logger.level)
 
             return retval, profiler_stats
 

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -32,9 +32,7 @@ def around(before: Optional[Callable] = None, after: Optional[Callable] = None) 
     This memory is transferred in the form of additional parameter ("_pipe")
     in the kwargs named argument dictionary.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import around
 
@@ -86,9 +84,7 @@ def caller(at_frame: int = DEFAULT_STACK_FRAME) -> str:
     Returns:
         The name of calling function/method.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import caller
 
@@ -108,6 +104,10 @@ def deltatime(logger: Optional[Logger] = None) -> Callable:
 
     Args:
         logger: Optional logger object for printing execution time to file.
+
+    Example::
+
+        ...
     """
 
     def decorate(func) -> CallableAnyT:
@@ -131,6 +131,10 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
     Args:
         logger: Optional logger object for printing execution time to file.
         stack_size: Stack size limit for profiler results.
+
+    Example::
+
+        ...
     """
     profiler = Profile()
 

--- a/pure_utils/debug.py
+++ b/pure_utils/debug.py
@@ -17,6 +17,108 @@ DEFAULT_STACK_SIZE: int = 10
 DEFAULT_STACK_FRAME: int = 2
 
 
+class ProfileResultPresenter:
+    def __init__(self, stats: Stats, amount: int) -> None:
+        self.stats = stats
+        self.amount = amount
+
+    @property
+    def indent(self) -> str:
+        return " " * 8
+
+    @property
+    def title(self) -> str:
+        return "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)"
+
+    def f8(self, x: float) -> str:
+        return f"{x:8.3f}"
+
+    def func_std_string(self, func_name) -> str:
+        if func_name[:2] == ("~", 0):
+            # special case for built-in functions
+            name = func_name[2]
+            if name.startswith("<") and name.endswith(">"):
+                return "{%s}" % name[1:-1]
+            else:
+                return name
+        else:
+            return "%s:%d(%s)" % func_name
+
+    def print_line(self, func) -> str:
+        lines = []
+        cc, nc, tt, ct, callers = self.stats.stats[func]
+        c = str(nc)
+
+        if nc != cc:
+            c = c + "/" + str(cc)
+
+        lines.append(f"{c.rjust(9)} ")
+        lines.append(f"{self.f8(tt)} ")
+
+        if nc == 0:
+            lines.append(f"{self.indent} ")
+        else:
+            lines.append(f"{self.f8(tt/nc)} ")
+
+        lines.append(f"{self.f8(ct)} ")
+
+        if cc == 0:
+            lines.append(f"{self.indent} ")
+        else:
+            lines.append(f"{self.f8(ct/cc)} ")
+
+        lines.append(self.func_std_string(func))
+
+        return "".join(lines)
+
+    def get_print_list(self) -> tuple[int, int]:
+        width = self.stats.max_name_len
+
+        if self.stats.fcn_list:
+            stat_list = self.stats.fcn_list[:]
+        else:
+            stat_list = list(self.stats.stats.keys())
+
+        count = len(stat_list)
+
+        if not stat_list:
+            return 0, stat_list
+
+        if count < len(self.stats.stats):
+            width = 0
+            for func in stat_list:
+                if len(self.func_std_string(func)) > width:
+                    width = len(self.func_std_string(func))
+
+        return width + 2, stat_list
+
+    def present(self) -> str:
+        lines = []
+
+        for filename in self.stats.files:
+            lines.append(filename)
+
+        for func in self.stats.top_level:
+            lines.append(f"{self.indent}{func[2]}")
+
+        lines.append(f"{self.stats.total_calls} function calls ")
+
+        if self.stats.total_calls != self.stats.prim_calls:
+            lines.append(f"({self.stats.prim_calls!r} primitive calls) ")
+
+        lines.append(f"in {self.stats.total_tt:.3f} seconds\n\n")
+
+        width, list = self.get_print_list()
+
+        if list:
+            lines.append("Ordered by: cumulative time, function name\n\n")
+            lines.append(f"{self.title}\n")
+            for func in list:
+                lines.append(f"{self.print_line(func)}\n")
+
+        return "".join(lines)
+
+
 def around(before: Optional[Callable] = None, after: Optional[Callable] = None) -> Callable:
     """Add additional behavior before and after execution of decorated function.
 
@@ -31,6 +133,9 @@ def around(before: Optional[Callable] = None, after: Optional[Callable] = None) 
 
     This memory is transferred in the form of additional parameter ("_pipe")
     in the kwargs named argument dictionary.
+
+    Raises:
+        ValueError: If one of the handlers (`before`, `after`) is not specified.
 
     Example::
 
@@ -51,11 +156,31 @@ def around(before: Optional[Callable] = None, after: Optional[Callable] = None) 
         # before!
         # in da func
         # after: some data (from before to after handlers) !
+
+        # !!! Use around with only BEFORE handler !!!
+        @around(before=before_handler)
+        def func2():
+            print("in da func2")
+        # before!
+        # in da func2
+
+        # !!! Use around with only AFTER handler !!!
+        @around(after=after_handler)
+        def func3():
+            print("in da func3")
+        # after!
+        # in da func3
     """
 
     def decorate(func) -> CallableAnyT:
         @wraps(func)
         def wrapper(*args, **kwargs):
+            if not before and not after:
+                raise ValueError(
+                    "One of the handlers (`before`, `after`) is not specified. Read the doc - "
+                    "https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.around"
+                )
+
             _buffer = {}
             _args, _kwargs = (deepcopy(args), kwargs.copy())
 
@@ -89,12 +214,12 @@ def caller(at_frame: int = DEFAULT_STACK_FRAME) -> str:
         from pure_utils import caller
 
         def func1(*args, **kwargs):
-            print(f"I'am 'func1'. '{caller()}' called me.")
+            print(f"I'am 'func1', '{caller()}' called me.")
 
         def func2(*args, **kwargs):
             return func1()
 
-        func2()  # I'am 'func1'. 'func2' called me.
+        func2()  # I'am 'func1', 'func2' called me.
     """
     return str(stack()[at_frame].function)
 
@@ -107,17 +232,39 @@ def deltatime(logger: Optional[Logger] = None) -> Callable:
 
     Example::
 
-        ...
+        from pure_utils import deltatime
+
+        @deltatime()
+        def aim_func():
+            for _ in range(1, 1000_000):
+                ...
+
+        result, delta = aim_func()
+        print(f"Execution time of aim_func: {delta} sec.")
+        # Execution time of aim_func: 0.025 sec.
+
+        # !!! Or use decorator with logger (side effect) !!!
+
+        from logging import getLogger, DEBUG, basicConfig
+        basicConfig(level=DEBUG)
+
+        @deltatime(logger=getLogger())
+        def aim_func2():
+            for _ in range(1, 1000_000):
+                ...
+
+        result, _ = aim_func2()
+        # DEBUG:root:[DELTATIME]: 'aim_func2' (0.025 sec.)
     """
 
     def decorate(func) -> CallableAnyT:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> tuple[Any, float]:
             t0 = time()
             retval = func(*args, **kwargs)
             delta = float(f"{time() - t0:.3f}")
             if logger:
-                logger.debug(f"[DELTATIME]: '{func.__name__}' ({delta} sec.)")
+                logger.log(msg=f"[DELTATIME]: '{func.__name__}' ({delta} sec.)", level=logger.level)
             return retval, delta
 
         return wrapper
@@ -134,26 +281,61 @@ def profileit(logger: Optional[Logger] = None, stack_size: int = DEFAULT_STACK_S
 
     Example::
 
+    from pure_utils import profileit
+
+    def func1():
         ...
+
+    def func2():
+        func1()
+
+    def func3():
+        func2()
+
+    @profileit()
+    def func4():
+        func3()
+
+    _, profile_info = func4()
+    print(profile_info)
+    # 5 function calls in 0.000 seconds
+    #    Ordered by: cumulative time, function name
+    #    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+    #         1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
+    #         1    0.000    0.000    0.000    0.000 scriptname.py:13(func4)
+    #         1    0.000    0.000    0.000    0.000 scriptname.py:10(func3)
+    #         1    0.000    0.000    0.000    0.000 scriptname.py:7(func2)
+    #         1    0.000    0.000    0.000    0.000 scriptname.py:4(func1)
+    # <pstats.Stats object at 0x10cf1a390>
+
+    # !!! Or use decorator with logger (side effect) !!!
+
+    from logging import getLogger, DEBUG, basicConfig
+    basicConfig(level=DEBUG)
+
+    @profileit(logger=getLogger())
+    def func4():
+        func3()
+
+    func4()
     """
     profiler = Profile()
 
     def decorate(func) -> CallableAnyT:
         @wraps(func)
-        def wrapper(*args, **kwargs):
-            result = None
+        def wrapper(*args, **kwargs) -> tuple[Any, Stats]:
+            retval = None
             try:
-                result = profiler.runcall(func, *args, **kwargs)
+                retval = profiler.runcall(func, *args, **kwargs)
             finally:
-                stack_info = (
-                    Stats(profiler)
-                    .strip_dirs()
-                    .sort_stats("cumulative", "name")
-                    .print_stats(stack_size)
-                )
+                profiler_stats = Stats(profiler).strip_dirs().sort_stats("cumulative", "name")
+
+                # s = stats2str(profiler_stats, stack_size)
+                s = ProfileResultPresenter(profiler_stats, stack_size).present()
                 if logger:
-                    logger.debug(f"[PROFILEIT]: {stack_info}")
-            return result, stack_info
+                    # logger.log(msg=f"[PROFILEIT]: {s}", level=logger.level)
+                    print(s)
+            return retval, profiler_stats
 
         return wrapper
 

--- a/pure_utils/dt.py
+++ b/pure_utils/dt.py
@@ -35,9 +35,7 @@ def apply_tz(dt: datetime, tz: str = "UTC", /) -> datetime:
     Returns:
         A new datetime object in specified timezone.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from datetime import datetime, UTC
         from pure_utils import apply_tz
@@ -57,9 +55,7 @@ def iso2format(isostr: str, fmt: str, /) -> str:
     Returns:
         Datetime string in specified format.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import iso2format, YMD
 
@@ -79,9 +75,7 @@ def iso2dmy(isostr: str, /) -> str:
     Returns:
         Datetime string in DMY format (DD.MM.YYYY).
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import iso2dmy
 
@@ -101,9 +95,7 @@ def iso2ymd(isostr: str, /) -> str:
     Returns:
         Datetime string in YMD format (YYYY-MM-DD).
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import iso2ymd
 
@@ -128,9 +120,7 @@ def round_by(dt: datetime, /, *, boundary: str) -> datetime:
     Raises:
         ValueError: If `boundary` is invalid.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from datetime import datetime
         from pure_utils import round_by

--- a/pure_utils/profiler.py
+++ b/pure_utils/profiler.py
@@ -1,44 +1,28 @@
 """Helper classes for working with the cProfile."""
 
 from cProfile import Profile
-from pstats import Stats
-from typing import Any, Mapping, Sequence, Type, TypeAlias
+from typing import Any, Type
 
-SerializedStatsT: TypeAlias = str | bytes | Mapping
+from ._pstats import PStats, PStatsSerializer, SerializedPStatsT
 
-
-class BaseStatsSerializer:
-    """Base class for serializer of profiling results."""
-
-    def __init__(self, stats: Stats, amount: int) -> None:
-        self.stats = stats
-        self.amount = amount
-
-    def serialize(self) -> SerializedStatsT:
-        """Interface for serialization method of profiling results.
-
-        Must be implemented in child classes.
-
-        Raises:
-            NotImplementedError: If called directly.
-        """
-        raise NotImplementedError
+__all__ = ["Profiler"]
 
 
 class Profiler:
     """..."""
 
     def __init__(self) -> None:
+        """Initialize profiler object."""
         self._profile = Profile()
 
     @property
-    def stats(self) -> Stats:
+    def pstats(self) -> PStats:
         """...
 
         Returns:
             ...
         """
-        return Stats(self._profile).strip_dirs().sort_stats("cumulative", "name")
+        return PStats(self._profile).strip_dirs().sort_stats("cumulative", "name")
 
     def profile(self, func, *args, **kwargs) -> Any:
         """...
@@ -50,7 +34,9 @@ class Profiler:
         """
         self._profile.runcall(func, *args, **kwargs)
 
-    def serialize_stats(self, *, serializer: Type[BaseStatsSerializer], stack_size: int) -> str:
+    def serialize_stats(
+        self, *, serializer: Type[PStatsSerializer], stack_size: int
+    ) -> SerializedPStatsT:
         """...
 
         Args:
@@ -60,145 +46,4 @@ class Profiler:
         Returns:
             ....
         """
-        return serializer(self.stats, stack_size).serialize()
-
-
-class StringProfileStatsSerializer(BaseStatsSerializer):
-    """..."""
-
-    @property
-    def indent(self) -> str:
-        """...
-
-        Returns:
-            ...
-        """
-        return " " * 8
-
-    @property
-    def title(self) -> str:
-        """...
-
-        Returns:
-            ...
-        """
-        return "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)"
-
-    def f8(self, x: float) -> str:
-        """...
-
-        Returns:
-            ...
-        """
-        return f"{x:8.3f}"
-
-    def func_std_string(self, func_name) -> str:
-        """...
-
-        Args:
-            func_name: ...
-
-        Returns:
-            ...
-        """
-        if func_name[:2] == ("~", 0):
-            # special case for built-in functions
-            name = func_name[2]
-            if name.startswith("<") and name.endswith(">"):
-                return "{%s}" % name[1:-1]
-            else:
-                return name
-        else:
-            return "%s:%d(%s)" % func_name
-
-    def print_line(self, func) -> str:
-        """...
-
-        Args:
-            func: ...
-
-        Returns:
-            ...
-        """
-        lines = []
-        cc, nc, tt, ct, callers = self.stats.stats[func]  # type: ignore
-        c = str(nc)
-
-        if nc != cc:
-            c = c + "/" + str(cc)
-
-        lines.append(f"{c.rjust(9)} ")
-        lines.append(f"{self.f8(tt)} ")
-
-        if nc == 0:
-            lines.append(f"{self.indent} ")
-        else:
-            lines.append(f"{self.f8(tt / nc)} ")
-
-        lines.append(f"{self.f8(ct)} ")
-
-        if cc == 0:
-            lines.append(f"{self.indent} ")
-        else:
-            lines.append(f"{self.f8(ct / cc)} ")
-
-        lines.append(self.func_std_string(func))
-
-        return "".join(lines)
-
-    def get_func_list(self) -> tuple[int, Sequence]:
-        """...
-
-        Returns:
-            ...
-        """
-        width = self.stats.max_name_len  # type: ignore
-
-        if self.stats.fcn_list:  # type: ignore
-            func_list = self.stats.fcn_list[:]  # type: ignore
-        else:
-            func_list = list(self.stats.stats.keys())  # type: ignore
-
-        count = len(func_list)
-
-        if not func_list:
-            return 0, func_list
-
-        if count < len(self.stats.stats):  # type: ignore
-            width = 0
-            for func in func_list:
-                if len(self.func_std_string(func)) > width:
-                    width = len(self.func_std_string(func))
-
-        return width + 2, func_list
-
-    def serialize(self) -> str:
-        """...
-
-        Returns:
-            ...
-        """
-        lines = []
-
-        for filename in self.stats.files:  # type: ignore
-            lines.append(filename)
-
-        for func in self.stats.top_level:  # type: ignore
-            lines.append(f"{self.indent}{func[2]}")
-
-        lines.append(f"{self.stats.total_calls} function calls ")  # type: ignore
-
-        if self.stats.total_calls != self.stats.prim_calls:  # type: ignore
-            lines.append(f"({self.stats.prim_calls!r} primitive calls) ")  # type: ignore
-
-        lines.append(f"in {self.stats.total_tt:.3f} seconds\n\n")  # type: ignore
-
-        _, func_list = self.get_func_list()
-
-        if func_list:
-            lines.append("Ordered by: cumulative time, function name\n\n")
-            lines.append(f"{self.title}\n")
-            for func in func_list:
-                lines.append(f"{self.print_line(func)}\n")
-
-        return "".join(lines)
+        return serializer(self.pstats, stack_size).serialize()

--- a/pure_utils/profiler.py
+++ b/pure_utils/profiler.py
@@ -1,0 +1,202 @@
+"""Helper classes for working with the cProfile."""
+
+from cProfile import Profile
+from pstats import Stats
+from typing import Any, Mapping
+
+
+class BaseStatsSerializer:
+    """Base class for serializer of profiling results."""
+
+    def __init__(self, stats: Stats, amount: int) -> None:
+        self.stats = stats
+        self.amount = amount
+
+    def serialize(self) -> str | bytes | Mapping:
+        """Interface for serialization method of profiling results.
+
+        Must be implemented in child classes.
+
+        Raises:
+            NotImplementedError: If called directly.
+        """
+        raise NotImplementedError
+
+
+class Profiler:
+    """..."""
+
+    def __init__(self) -> None:
+        self._profile = Profile()
+
+    @property
+    def stats(self) -> Stats:
+        """...
+
+        Returns:
+            ...
+        """
+        return Stats(self._profile).strip_dirs().sort_stats("cumulative", "name")
+
+    def profile(self, func, *args, **kwargs) -> Any:
+        """...
+
+        Args:
+            func: ...
+            *args: ...
+            **kwargs: ...
+        """
+        self._profile.runcall(func, *args, **kwargs)
+
+    def serialize_stats(self, *, serializer: BaseStatsSerializer, stack_size: int) -> str:
+        """...
+
+        Args:
+            serializer: ...
+            stack_size: ...
+
+        Returns:
+            ....
+        """
+        return serializer(self.stats, stack_size).serialize()
+
+
+class StringProfileStatsSerializer(BaseStatsSerializer):
+    """..."""
+
+    @property
+    def indent(self) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        return " " * 8
+
+    @property
+    def title(self) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        return "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)"
+
+    def f8(self, x: float) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        return f"{x:8.3f}"
+
+    def func_std_string(self, func_name) -> str:
+        """...
+
+        Args:
+            func_name: ...
+
+        Returns:
+            ...
+        """
+        if func_name[:2] == ("~", 0):
+            # special case for built-in functions
+            name = func_name[2]
+            if name.startswith("<") and name.endswith(">"):
+                return "{%s}" % name[1:-1]
+            else:
+                return name
+        else:
+            return "%s:%d(%s)" % func_name
+
+    def print_line(self, func) -> str:
+        """...
+
+        Args:
+            func: ...
+
+        Returns:
+            ...
+        """
+        lines = []
+        cc, nc, tt, ct, callers = self.stats.stats[func]
+        c = str(nc)
+
+        if nc != cc:
+            c = c + "/" + str(cc)
+
+        lines.append(f"{c.rjust(9)} ")
+        lines.append(f"{self.f8(tt)} ")
+
+        if nc == 0:
+            lines.append(f"{self.indent} ")
+        else:
+            lines.append(f"{self.f8(tt / nc)} ")
+
+        lines.append(f"{self.f8(ct)} ")
+
+        if cc == 0:
+            lines.append(f"{self.indent} ")
+        else:
+            lines.append(f"{self.f8(ct / cc)} ")
+
+        lines.append(self.func_std_string(func))
+
+        return "".join(lines)
+
+    def get_func_list(self) -> tuple[int, int]:
+        """...
+
+        Returns:
+            ...
+        """
+        width = self.stats.max_name_len
+
+        if self.stats.fcn_list:
+            func_list = self.stats.fcn_list[:]
+        else:
+            func_list = list(self.stats.stats.keys())
+
+        count = len(func_list)
+
+        if not func_list:
+            return 0, func_list
+
+        if count < len(self.stats.stats):
+            width = 0
+            for func in func_list:
+                if len(self.func_std_string(func)) > width:
+                    width = len(self.func_std_string(func))
+
+        return width + 2, func_list
+
+    def serialize(self) -> str:
+        """...
+
+        Returns:
+            ...
+        """
+        lines = []
+
+        for filename in self.stats.files:
+            lines.append(filename)
+
+        for func in self.stats.top_level:
+            lines.append(f"{self.indent}{func[2]}")
+
+        lines.append(f"{self.stats.total_calls} function calls ")
+
+        if self.stats.total_calls != self.stats.prim_calls:
+            lines.append(f"({self.stats.prim_calls!r} primitive calls) ")
+
+        lines.append(f"in {self.stats.total_tt:.3f} seconds\n\n")
+
+        _, func_list = self.get_func_list()
+
+        if func_list:
+            lines.append("Ordered by: cumulative time, function name\n\n")
+            lines.append(f"{self.title}\n")
+            for func in func_list:
+                lines.append(f"{self.print_line(func)}\n")
+
+        return "".join(lines)

--- a/pure_utils/profiler.py
+++ b/pure_utils/profiler.py
@@ -3,7 +3,7 @@
 from cProfile import Profile
 from typing import Any, Type
 
-from ._pstats import PStats, PStatsSerializer, SerializedPStatsT
+from pure_utils._pstats import PStats, PStatsSerializer, SerializedPStatsT
 
 __all__ = ["Profiler"]
 

--- a/pure_utils/profiler.py
+++ b/pure_utils/profiler.py
@@ -2,7 +2,9 @@
 
 from cProfile import Profile
 from pstats import Stats
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence, Type, TypeAlias
+
+SerializedStatsT: TypeAlias = str | bytes | Mapping
 
 
 class BaseStatsSerializer:
@@ -12,7 +14,7 @@ class BaseStatsSerializer:
         self.stats = stats
         self.amount = amount
 
-    def serialize(self) -> str | bytes | Mapping:
+    def serialize(self) -> SerializedStatsT:
         """Interface for serialization method of profiling results.
 
         Must be implemented in child classes.
@@ -48,7 +50,7 @@ class Profiler:
         """
         self._profile.runcall(func, *args, **kwargs)
 
-    def serialize_stats(self, *, serializer: BaseStatsSerializer, stack_size: int) -> str:
+    def serialize_stats(self, *, serializer: Type[BaseStatsSerializer], stack_size: int) -> str:
         """...
 
         Args:
@@ -119,7 +121,7 @@ class StringProfileStatsSerializer(BaseStatsSerializer):
             ...
         """
         lines = []
-        cc, nc, tt, ct, callers = self.stats.stats[func]
+        cc, nc, tt, ct, callers = self.stats.stats[func]  # type: ignore
         c = str(nc)
 
         if nc != cc:
@@ -144,25 +146,25 @@ class StringProfileStatsSerializer(BaseStatsSerializer):
 
         return "".join(lines)
 
-    def get_func_list(self) -> tuple[int, int]:
+    def get_func_list(self) -> tuple[int, Sequence]:
         """...
 
         Returns:
             ...
         """
-        width = self.stats.max_name_len
+        width = self.stats.max_name_len  # type: ignore
 
-        if self.stats.fcn_list:
-            func_list = self.stats.fcn_list[:]
+        if self.stats.fcn_list:  # type: ignore
+            func_list = self.stats.fcn_list[:]  # type: ignore
         else:
-            func_list = list(self.stats.stats.keys())
+            func_list = list(self.stats.stats.keys())  # type: ignore
 
         count = len(func_list)
 
         if not func_list:
             return 0, func_list
 
-        if count < len(self.stats.stats):
+        if count < len(self.stats.stats):  # type: ignore
             width = 0
             for func in func_list:
                 if len(self.func_std_string(func)) > width:
@@ -178,18 +180,18 @@ class StringProfileStatsSerializer(BaseStatsSerializer):
         """
         lines = []
 
-        for filename in self.stats.files:
+        for filename in self.stats.files:  # type: ignore
             lines.append(filename)
 
-        for func in self.stats.top_level:
+        for func in self.stats.top_level:  # type: ignore
             lines.append(f"{self.indent}{func[2]}")
 
-        lines.append(f"{self.stats.total_calls} function calls ")
+        lines.append(f"{self.stats.total_calls} function calls ")  # type: ignore
 
-        if self.stats.total_calls != self.stats.prim_calls:
-            lines.append(f"({self.stats.prim_calls!r} primitive calls) ")
+        if self.stats.total_calls != self.stats.prim_calls:  # type: ignore
+            lines.append(f"({self.stats.prim_calls!r} primitive calls) ")  # type: ignore
 
-        lines.append(f"in {self.stats.total_tt:.3f} seconds\n\n")
+        lines.append(f"in {self.stats.total_tt:.3f} seconds\n\n")  # type: ignore
 
         _, func_list = self.get_func_list()
 

--- a/pure_utils/profiler.py
+++ b/pure_utils/profiler.py
@@ -1,15 +1,28 @@
 """Helper classes for working with the cProfile."""
 
 from cProfile import Profile
-from typing import Any, Type
+from typing import Callable, ParamSpec, Type, TypeVar
 
-from pure_utils._pstats import PStats, PStatsSerializer, SerializedPStatsT
+from pure_utils._pstats import ProfilerStatsT, PStats, PStatsSerializer
 
 __all__ = ["Profiler"]
 
 
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
 class Profiler:
-    """..."""
+    """A class provides a simple interface for profiling code.
+
+    Example::
+
+        from pure_utils import Profiler
+
+        profiler = Profiler()
+        some_function_retval = profiler.profile(some_func, *func_args, **func_kwargs)
+        profile_result = profiler.serialize_result(SomeProfilerStatsSerializer())
+    """
 
     def __init__(self) -> None:
         """Initialize profiler object."""
@@ -17,33 +30,32 @@ class Profiler:
 
     @property
     def pstats(self) -> PStats:
-        """...
-
-        Returns:
-            ...
-        """
+        """Get raw profile stats."""
         return PStats(self._profile).strip_dirs().sort_stats("cumulative", "name")
 
-    def profile(self, func, *args, **kwargs) -> Any:
-        """...
+    def profile(self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+        """Profile function.
 
         Args:
-            func: ...
-            *args: ...
-            **kwargs: ...
+            func: Function for profiling
+            *args: Profiling function positional arguments.
+            **kwargs: Profiling function named arguments.
+
+        Return:
+            Native profiling function return value.
         """
-        self._profile.runcall(func, *args, **kwargs)
+        return self._profile.runcall(func, *args, **kwargs)
 
-    def serialize_stats(
+    def serialize_result(
         self, *, serializer: Type[PStatsSerializer], stack_size: int
-    ) -> SerializedPStatsT:
-        """...
+    ) -> ProfilerStatsT:
+        """Serialize profiler result with custom serializer class.
 
         Args:
-            serializer: ...
-            stack_size: ...
+            serializer: Serializer class.
+            stack_size: Stack size for limitation
 
         Returns:
-            ....
+            Serialized profiler result.
         """
         return serializer(self.pstats, stack_size).serialize()

--- a/pure_utils/strings.py
+++ b/pure_utils/strings.py
@@ -17,9 +17,7 @@ def genstr(length: int = 10, /, *, is_uppercase: bool = False) -> str:
     Returns:
         Generated ASCII-string with random letters.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import genstr
 
@@ -45,9 +43,7 @@ def gzip(string: str | bytes, /, *, level: int = 9) -> bytes:
     Returns:
         Compressed string in bytes.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import gzip
 
@@ -69,9 +65,7 @@ def gunzip(compressed_string: bytes, /) -> str:
     Returns:
         Decompressed string from bytes.
 
-    Usage:
-
-    .. code-block:: python
+    Example::
 
         from pure_utils import gzip, gunzip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["tests*"]
 
 [project]
 name = "pure-utils"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
   {name="Peter Bro", email="p3t3rbr0@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.21.1"]
 build-backend = "hatchling.build"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,20 +47,12 @@ dev = [
     "mypy==1.8.0",
     "isort==5.13.2",
     "flake8==6.1.0",
-    "pyproject-flake8==6.1.0",
     "black==24.1.1",
     "pydocstyle==6.3.0",
     "pytest==8.0.0",
     "pytest-cov==4.1.0",
     "pytest-mock==3.12.0",
 ]
-
-[tool.flake8]
-max-complexity = 10
-max-line-length = 100
-ignore = ["D"]
-extend-ignore = ["E203", "W503"]
-exclude = [".git", "venv", "__pycache__"]
 
 [tool.mypy]
 exclude = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools==69.0.3"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.setuptools]
 include-package-data = false
@@ -68,8 +68,9 @@ convention = "google"
 match-dir = "^(?!tests|.docs).+$"
 
 [tool.pytest.ini_options]
-pythonpath = ["pure_utils"]
-testpaths = ["tests"]
+addopts = ["--import-mode=importlib"]
+pythonpath = "pure_utils"
+testpaths = "tests"
 python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = ["Sphinx==7.2.6", "furo==2024.1.29"]
 dev = [
     "mypy==1.8.0",
     "isort==5.13.2",
-    "flake8==6.1.0",
+    "flake8==7.0.0",
     "black==24.1.1",
     "pydocstyle==6.3.0",
     "pytest==8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exclude_lines = [
 
 [tool.coverage.run]
 branch = true
-omit = ["pure_utils/__init__.py",]
+omit = ["pure_utils/__init__.py", "pure_utils/_pstats.py"]
 
 [tool.coverage.html]
 directory = "coverage_report"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture(scope="function")
+def with_fake_profile_runcall(mocker):
+    def runcall(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    profile = mocker.patch("cProfile.Profile")
+    profile.runcall = runcall

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -2,13 +2,21 @@ import pytest
 from debug import around, caller, deltatime, profileit
 
 
-class TestDeltatime: ...
+class TestDeltatime:
+    def test_sample(self):
+        assert True
 
 
-class TestProfileit: ...
+class TestProfileit:
+    def test_sample(self):
+        assert True
 
 
-class TestCaller: ...
+class TestCaller:
+    def test_sample(self):
+        assert True
 
 
-class TestAround: ...
+class TestAround:
+    def test_sample(self):
+        assert True

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -2,6 +2,52 @@ import pytest
 from debug import around, caller, deltatime, profileit
 
 
+class TestAround:
+    def before_handler(self, *args, **kwargs):
+        assert "_pipe" in kwargs
+        assert kwargs["_pipe"] == {}
+        kwargs["_pipe"]["key"] = "some data (from before to after handlers)"
+
+    def after_handler(self, *args, **kwargs):
+        assert kwargs["_pipe"]["key"] == "some data (from before to after handlers)"
+
+    def after_handler_without_pipe(self, *args, **kwargs):
+        assert kwargs["_pipe"] == {}
+
+    @around(before=before_handler, after=after_handler)
+    def func1(self, *args, **kwargs):
+        return "some result"
+
+    @around(before=before_handler)
+    def func2(self, *args, **kwargs):
+        return "some result"
+
+    @around(after=after_handler_without_pipe)
+    def func3(self, *args, **kwargs):
+        return "some result"
+
+    @around()
+    def func4(self, *args, **kwargs):
+        return "some result"
+
+    def test_with_before_and_after_handlers(self):
+        assert self.func1() == "some result"
+
+    def test_with_before_handler_only(self):
+        assert self.func2() == "some result"
+
+    def test_with_after_handler_only(self):
+        assert self.func3() == "some result"
+
+    def test_without_before_and_after_handlers(self):
+        with pytest.raises(ValueError) as excinfo:
+            self.func4()
+            assert excinfo.value.message == (
+                "One of the handlers (`before`, `after`) is not specified. Read the doc - "
+                "https://p3t3rbr0.github.io/py3-pure-utils/refs/debug.html#debug.around"
+            )
+
+
 class TestDeltatime:
     def test_sample(self):
         assert True
@@ -13,10 +59,22 @@ class TestProfileit:
 
 
 class TestCaller:
-    def test_sample(self):
-        assert True
+    def func1(self, at_frame=2):
+        return caller(at_frame)
 
+    def func2(self, *args, **kwargs):
+        return self.func1(*args, **kwargs)
 
-class TestAround:
-    def test_sample(self):
-        assert True
+    def func3(self, *args, **kwargs):
+        return self.func2(*args, **kwargs)
+
+    def func4(self, *args, **kwargs):
+        return self.func3(*args, **kwargs)
+
+    def test_with_default_params(self):
+        assert self.func2() == "func2"
+        assert self.func4() == "func2"
+
+    def test_with_at_frame(self):
+        assert self.func3(at_frame=3) == "func3"
+        assert self.func4(at_frame=4) == "func4"

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 import pytest
 from debug import around, caller, deltatime, profileit
 
@@ -48,16 +50,6 @@ class TestAround:
             )
 
 
-class TestDeltatime:
-    def test_sample(self):
-        assert True
-
-
-class TestProfileit:
-    def test_sample(self):
-        assert True
-
-
 class TestCaller:
     def func1(self, at_frame=2):
         return caller(at_frame)
@@ -78,3 +70,36 @@ class TestCaller:
     def test_with_at_frame(self):
         assert self.func3(at_frame=3) == "func3"
         assert self.func4(at_frame=4) == "func4"
+
+
+class TestDeltatime:
+    @deltatime()
+    def func(self):
+        return True
+
+    @deltatime(logger=getLogger())
+    def func2(self):
+        return True
+
+    def test_with_side_effect(self, mocker):
+        log_mock = mocker.patch("logging.Logger.log")
+
+        retval, delta = self.func2()
+
+        assert retval is True
+        assert isinstance(delta, float)
+        log_mock.assert_called_once()
+
+    def test_without_side_effect(self, mocker):
+        log_mock = mocker.patch("logging.Logger.log")
+
+        retval, delta = self.func()
+
+        assert retval is True
+        assert isinstance(delta, float)
+        log_mock.assert_not_called()
+
+
+class TestProfileit:
+    def test_sample(self):
+        assert True

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,14 @@
+import pytest
+from debug import around, caller, deltatime, profileit
+
+
+class TestDeltatime: ...
+
+
+class TestProfileit: ...
+
+
+class TestCaller: ...
+
+
+class TestAround: ...

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -116,14 +116,6 @@ class TestProfileit:
         return self.func2()
 
     @pytest.fixture(scope="function")
-    def with_fake_runcall(self, mocker):
-        def runcall(func, *args, **kwargs):
-            return func(*args, **kwargs)
-
-        profile = mocker.patch("profiler.Profile")
-        profile.runcall = runcall
-
-    @pytest.fixture(scope="function")
     def pstats(self):
         return (
             "5 function calls in 0.000 seconds"
@@ -137,7 +129,7 @@ class TestProfileit:
             "<pstats.Stats object at 0x10cf1a390>"
         )
 
-    def test_with_side_effect(self, mocker, pstats, with_fake_runcall):
+    def test_with_side_effect(self, mocker, pstats, with_fake_profile_runcall):
         log_mock = mocker.patch("logging.Logger.log")
         mocker.patch("debug.Profiler.serialize_result", return_value=pstats)
 
@@ -151,7 +143,7 @@ class TestProfileit:
 
         log_mock.assert_called_once()
 
-    def test_without_side_effect(self, mocker, pstats, with_fake_runcall):
+    def test_without_side_effect(self, mocker, pstats, with_fake_profile_runcall):
         log_mock = mocker.patch("logging.Logger.log")
         mocker.patch("debug.Profiler.serialize_result", return_value=pstats)
 

--- a/tests/test_dt.py
+++ b/tests/test_dt.py
@@ -43,6 +43,13 @@ class TestIso2Dmy:
         assert isinstance(formatted_dt, str)
         assert formatted_dt == expected
 
+    @pytest.mark.skipif(version_info != (3, 10), reason="python3.10 only")
+    def test_with_iso_datetime_string_310_compatible(self):
+        formatted_dt = iso2ymd("2009-08-09T18:31:42+03")
+        assert formatted_dt
+        assert isinstance(formatted_dt, str)
+        assert formatted_dt == "09.08.2009 18:31:42"
+
 
 class TestIso2Ymd:
     @pytest.mark.skipif(version_info < (3, 11), reason="requires python3.11 or higher")
@@ -64,6 +71,13 @@ class TestIso2Ymd:
         assert isinstance(formatted_dt, str)
         assert formatted_dt == expected
 
+    @pytest.mark.skipif(version_info != (3, 10), reason="python3.10 only")
+    def test_with_iso_datetime_string_310_compatible(self):
+        formatted_dt = iso2ymd("2009-08-09T18:31:42+03")
+        assert formatted_dt
+        assert isinstance(formatted_dt, str)
+        assert formatted_dt == "2009-08-09 18:31:42"
+
 
 class TestIso2Format:
     @pytest.mark.skipif(version_info < (3, 11), reason="requires python3.11 or higher")
@@ -80,6 +94,13 @@ class TestIso2Format:
         assert formatted_dt
         assert isinstance(formatted_dt, str)
         assert formatted_dt == expected
+
+    @pytest.mark.skipif(version_info != (3, 10), reason="python3.10 only")
+    def test_with_iso_datetime_string_310_compatible(self):
+        formatted_dt = iso2format("2009-08-09T18:31:42+03", "%d.%m.%Y %H:%M:%S")
+        assert formatted_dt
+        assert isinstance(formatted_dt, str)
+        assert formatted_dt == "09.08.2009 18:31:42"
 
 
 class TestRoundBy:

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,26 @@
+import pytest
+from _pstats import PStatsSerializer
+from profiler import Profiler
+
+
+class DummuStringPStatsSerializer(PStatsSerializer):
+    def serialize(self):
+        return "Some serialized data"
+
+
+def func_for_profiling():
+    return True
+
+
+class TestProfiler:
+    def test_profiling_result_as_string(self, mocker, with_fake_profile_runcall):
+        mocker.patch("profiler.PStats", return_value=mocker.Mock())
+
+        profiler = Profiler()
+        retval = profiler.profile(func_for_profiling)
+        profiling_result = profiler.serialize_result(
+            serializer=DummuStringPStatsSerializer, stack_size=10
+        )
+
+        assert retval is True
+        assert profiling_result == "Some serialized data"


### PR DESCRIPTION
* Add several tests (for `dt` module) for python3.10 only.
* Add new module - `debug` (utilities for debugging and development).
* Add new module - `profiler` (helper classes for working with the cProfile).
* Refactor .docs/Makefile
* Add support Python3.12 into ci scenario.
* Use flake8 explicitly into Makefile and ci scenario.
* Remove `pyproject-flake8` optional dependencies, because it's orphaned on github.